### PR TITLE
Allow partially mapped methods

### DIFF
--- a/src/main/java/org/parchmentmc/librarian/forgegradle/ParchmentChannelProvider.java
+++ b/src/main/java/org/parchmentmc/librarian/forgegradle/ParchmentChannelProvider.java
@@ -1,6 +1,6 @@
 /*
  * Librarian
- * Copyright (C) 2022 ParchmentMC
+ * Copyright (C) 2021 ParchmentMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -388,10 +388,10 @@ public class ParchmentChannelProvider implements ChannelProvider {
     }
 
     // Converts a JVM parameter index (as used by the parchment export) to a SRG parameter index.
-    public static int jvmToSrg(IMethod srgMethod, int jvmIndex) {
+    protected int jvmToSrg(IMethod srgMethod, int jvmIndex) {
         String args = srgMethod.getDescriptor().substring(1, srgMethod.getDescriptor().lastIndexOf(')'));
         args = args.replaceAll("L.*?;", "L");
-        // Arrays are references wit only regular size, no matter if it's a long or double array
+        // Arrays are references always with a size of one regardless of the array type
         args = args.replaceAll("\\[+.", "L");
         // Non-static methods have an implicit this argument
         int currentIdx = srgMethod.getMetadata().containsKey("is_static") ? 0 : 1;

--- a/src/main/java/org/parchmentmc/librarian/forgegradle/ParchmentChannelProvider.java
+++ b/src/main/java/org/parchmentmc/librarian/forgegradle/ParchmentChannelProvider.java
@@ -1,6 +1,6 @@
 /*
  * Librarian
- * Copyright (C) 2021 ParchmentMC
+ * Copyright (C) 2022 ParchmentMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -225,18 +225,15 @@ public class ParchmentChannelProvider implements ChannelProvider {
 
         List<IParameter> srgParams = srgMethod == null ? ImmutableList.of() : ImmutableList.copyOf(srgMethod.getParameters());
         List<ParameterData> methodParams = ImmutableList.copyOf(methodData.getParameters());
-        // If the MCPConfig export is official (1.17+) and the # of params doesn't match, we need to skip it.
-        // This is because on non-official exports, the parameter SRG id can be reconstructed from method SRG name and parameter JVM index.
-        // This is not possible on official exports with the newer parameter SRG format.
-        if (constructorId == null && isOfficialExport && methodParams.size() != srgParams.size())
+
+        if (isOfficialExport && srgMethod == null)
             return;
 
-        for (int i = 0; i < methodParams.size(); i++) {
-            ParameterData parameter = methodParams.get(i);
+        for (ParameterData parameter : methodParams) {
             String srgParam;
             // official export == 1.17+
             if (isOfficialExport) {
-                srgParam = srgParams.get(i).getMapped();
+                srgParam = srgParams.get(jvmToSrg(srgMethod, parameter.getIndex())).getMapped();
             } else if (constructorId != null) {
                 srgParam = String.format("p_i%s_%d_", constructorId, parameter.getIndex());
             } else {
@@ -390,6 +387,27 @@ public class ParchmentChannelProvider implements ChannelProvider {
         return MavenArtifactDownloader.manual(project, "de.oceanlabs.mcp:mcp_config:" + version + "@zip", false);
     }
 
+    // Converts a JVM parameter index (as used by the parchment export) to a SRG parameter index.
+    public static int jvmToSrg(IMethod srgMethod, int jvmIndex) {
+        String args = srgMethod.getDescriptor().substring(1, srgMethod.getDescriptor().lastIndexOf(')'));
+        args = args.replaceAll("L.*?;", "L");
+        // Arrays are references wit only regular size, no matter if it's a long or double array
+        args = args.replaceAll("\\[+.", "L");
+        // Non-static methods have an implicit this argument
+        int currentIdx = srgMethod.getMetadata().containsKey("is_static") ? 0 : 1;
+        int srgIdx = 0;
+        while (currentIdx < jvmIndex) {
+            // long and double increase the jvm index by 2
+            if (srgIdx < args.length() && args.charAt(srgIdx) == 'J' || args.charAt(srgIdx) == 'D') {
+                currentIdx += 2;
+            } else {
+                currentIdx += 1;
+            }
+            srgIdx += 1;
+        }
+        return srgIdx;
+    }
+    
     protected void writeCsv(String name, List<String[]> mappings, Path rootPath) throws IOException {
         if (mappings.size() <= 1)
             return;


### PR DESCRIPTION
This fixes #7 by implementing a mapper from JVM indices to source indices (as used by the SRG since 1.17). For that, it parses the method descriptor and the `is_static` metadata obtained from the SRG.

I have tested the changes in this PR with parchment `2022.03.13` on Forge `40.0.48`. I looked a several static and non-static methods that contained `long` and `double` and they were mapped correctly. Also in `FormattedCharSink` the two parameters that have names in parchment for that version got mapped now.